### PR TITLE
Apply validations on events if defined.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "pg", "~> 0.18"
 # Use Puma as the app server
 gem "puma", "~> 3.0"
 gem "active_model_serializers"
+gem "interactor-rails"
 
 gem "pry-rails"
 gem "jwt"
@@ -28,6 +29,7 @@ gem "jwt"
 
 group :development, :test do
   gem "rspec-rails", "~>3.5"
+  gem "factory_girl_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,11 @@ GEM
     diff-lcs (1.3)
     dotenv (2.2.0)
     erubis (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     ffi (1.9.18)
     formatador (0.2.5)
     globalid (0.3.7)
@@ -71,6 +76,10 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     i18n (0.8.1)
+    interactor (3.1.0)
+    interactor-rails (2.0.2)
+      interactor (~> 3.0)
+      rails (>= 3, < 5.1)
     jsonapi-renderer (0.1.2)
     jwt (1.5.6)
     listen (3.0.8)
@@ -181,7 +190,9 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   dotenv
+  factory_girl_rails
   guard-rspec
+  interactor-rails
   jwt
   listen (~> 3.0.5)
   pg (~> 0.18)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,12 +15,13 @@ class EventsController < ApplicationController
 
   # POST /events
   def create
-    @event = Event.new(event_params)
+    event  = Event.new(event_params)
+    result = CreateEvent.call(event: event)
 
-    if @event.save
-      render json: @event, status: :created, location: @event
+    if result.success?
+      render json: result.event, status: :created
     else
-      render json: @event.errors, status: :unprocessable_entity
+      render json: result.errors, status: :unprocessable_entity
     end
   end
 

--- a/app/interactions/create_event.rb
+++ b/app/interactions/create_event.rb
@@ -1,0 +1,32 @@
+class CreateEvent
+  include Interactor
+
+  def call
+    return if valid_event? && create_event
+    context.fail!(errors: context.errors)
+  end
+
+  private
+
+  def valid_event?
+    return true unless validator
+
+    result = validator.call(context.to_h)
+    result.success?.tap do |success|
+      context.errors = result.errors unless success
+    end
+  end
+
+  def validator
+    "Validate#{event.category}".safe_constantize
+  end
+
+  def event
+    context.event
+  end
+
+  def create_event
+    context.errors = event.errors&.messages unless event.valid?
+    event.save
+  end
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,7 @@ development:
 
 test:
   secret_key_base: 7f862b9980c50e599825e4887cc496ed3d0d253ea05f28cebb57d26abe0fedfa5612c9e7e7e06687edc7e80a18b55c8660e615c082304b92117c68ff0c9c32dc
+  jwt_secret: thisisajwtsecret
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :event do
+    category "MyString"
+  end
+end

--- a/spec/interactions/create_event_spec.rb
+++ b/spec/interactions/create_event_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe CreateEvent do
+  subject(:result) { described_class.call(some_context) }
+  let(:event) { build(:event) }
+  let(:some_context) do
+    { event: event }
+  end
+  let(:validator_str) { "Validate#{event.category}".classify }
+  let(:validator_double) { double(:validator_double) }
+  let(:success) { true }
+  let(:validator_result) do
+    double(:context, success?: success, errors: {})
+  end
+
+  before do
+    allow(validator_double).to receive(:call).and_return(validator_result)
+  end
+
+  it "executes a validator if it exists" do
+    stub_const(validator_str, validator_double)
+
+    expect(validator_double).to receive(:call)
+    result
+  end
+
+  it "doesn't blow up if a validator does NOT exist" do
+    expect { result }.to_not raise_error
+  end
+
+  context "when a validator fails" do
+    let(:success) { false }
+
+    it "fails execution" do
+      stub_const(validator_str, validator_double)
+
+      expect(result).to be_a_failure
+      expect(result.errors).to eq(validator_result.errors)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,13 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'spec_helper'
-require 'rspec/rails'
+require "spec_helper"
+require "rspec/rails"
+require "support/factory_girl"
+Dir[Rails.root.join("app/interactions/**/*")].each { |f| require f }
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end


### PR DESCRIPTION
As Events are posted, we can apply validations if a "validator" exists.
A "Validate#{event.category}".constantize naming convention is required.

For example, an event is POSTed with a category of `til_tweet`.  We
don't have any validators for that, so it gets created (assuming it
passes AR validations).  On the other hand, if an event with
`resume_site` gets POSTed and we have a validator class called
`ValidateResumeSite`, it will be executed.

All validators should have the `Interactor` module included.
The intention is define all future validators in a `interactions/validations`
directory.